### PR TITLE
Hide form elements if random submission is not checked

### DIFF
--- a/random/locallib.php
+++ b/random/locallib.php
@@ -65,9 +65,12 @@ class assign_submission_random extends assign_submission_plugin {
        
         $mform->addElement('filemanager', 'inputfiles', get_string('inputfiles','assignsubmission_random'), null, $fileoptions ); 
         $mform->addHelpButton('inputfiles', 'inputfiles','assignsubmission_random');
+        $mform->hideIf('inputfiles','assignsubmission_random_enabled','notchecked');
+       
          
         $mform->addElement('filemanager', 'outputfiles', get_string('outputfiles','assignsubmission_random'), null, $fileoptions ); 
-        $mform->addHelpButton('outputfiles', 'outputfiles','assignsubmission_random');             
+        $mform->addHelpButton('outputfiles', 'outputfiles','assignsubmission_random');
+        $mform->hideIf('outputfiles','assignsubmission_random_enabled','notchecked');
     }
     
     /**


### PR DESCRIPTION
Form elements "Assignments files" and "Solutions files" are always visible even if the user doesn't checked the random submission type. This additional code hide them if this submission type is not used.